### PR TITLE
Modify entrypoint logging and Dockerfile for k8s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,9 @@ ONBUILD RUN pip install --upgrade --no-cache-dir -r requirements.txt
 ONBUILD COPY . /usr/src/app/
 ONBUILD RUN pip install --upgrade --no-cache-dir -e /usr/src/app/
 
+COPY entrypoint.sh /usr/src/app/
+COPY uwsgi.ini /usr/src/app
+
 EXPOSE 8000
 
 ENTRYPOINT ["/usr/src/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-/usr/local/bin/invoke update >> /usr/src/app/invoke.log
+/usr/local/bin/invoke update
 
 source $HOME/.override_env
 
@@ -11,18 +11,18 @@ echo SITEURL=$SITEURL
 echo ALLOWED_HOSTS=$ALLOWED_HOSTS
 echo GEOSERVER_PUBLIC_LOCATION=$GEOSERVER_PUBLIC_LOCATION
 
-/usr/local/bin/invoke waitfordbs >> /usr/src/app/invoke.log
+/usr/local/bin/invoke waitfordbs
 
 echo "waitfordbs task done"
 
 echo "running migrations"
-/usr/local/bin/invoke migrations >> /usr/src/app/invoke.log
-/usr/local/bin/invoke statics >> /usr/src/app/invoke.log
+/usr/local/bin/invoke migrations
+/usr/local/bin/invoke statics
 
 echo "migrations task done"
-/usr/local/bin/invoke prepare >> /usr/src/app/invoke.log
+/usr/local/bin/invoke prepare
 echo "prepare task done"
-/usr/local/bin/invoke fixtures >> /usr/src/app/invoke.log
+/usr/local/bin/invoke fixtures
 echo "fixture task done"
 
 cmd="$@"


### PR DESCRIPTION
* The standard method of obtaining logs from running (or crashed)
  pods in kubernetes is to read them from stdout. This will remove
  the redirection to invoke.log, as it contains valuable info on
  if other geonode services are healthy or not and can help in
  debugging.

* Right now the Dockerfile in this repo and in the geonode monorepo
  do not appear to copy uwsgi.ini to the container image. This is
  really just a stopgap, as configuration files for containers
  should be stored in a kubernetes configmap rather than baked in
  to the image at build time.

Signed-off-by: Cullen Taylor <mctaylor@us.ibm.com>