### PR TITLE
set nginx host with custom port

### DIFF
--- a/docker/nginx/docker-entrypoint.sh
+++ b/docker/nginx/docker-entrypoint.sh
@@ -34,8 +34,18 @@ fi
 
 if [ -z "${HTTPS_HOST}" ]; then
         HTTP_SCHEME="http"
+        if [ $HTTP_PORT = "80" ]; then
+                PUBLIC_HOST=${HTTP_HOST}
+        else
+                PUBLIC_HOST="$HTTP_HOST:$HTTP_PORT"
+        fi
 else
         HTTP_SCHEME="https"
+        if [ $HTTPS_PORT = "443" ]; then
+                PUBLIC_HOST=${HTTPS_HOST}
+        else
+                PUBLIC_HOST="$HTTPS_HOST:$HTTPS_PORT"
+        fi
 fi
 
 export HTTP_SCHEME=${HTTP_SCHEME:-http}
@@ -43,11 +53,12 @@ export GEONODE_LB_HOST_IP=${GEONODE_LB_HOST_IP:-django}
 export GEONODE_LB_PORT=${GEONODE_LB_PORT:-8000}
 export GEOSERVER_LB_HOST_IP=${GEOSERVER_LB_HOST_IP:-geoserver}
 export GEOSERVER_LB_PORT=${GEOSERVER_LB_PORT:-8080}
+export PUBLIC_HOST=${PUBLIC_HOST}
 
 echo "Replacing environement variables"
-envsubst '\$HTTP_HOST \$HTTPS_HOST \$HTTP_SCHEME \$GEONODE_LB_HOST_IP \$GEONODE_LB_PORT \$GEOSERVER_LB_HOST_IP \$GEOSERVER_LB_PORT \$RESOLVER' < /etc/nginx/nginx.conf.envsubst > /etc/nginx/nginx.conf
-envsubst '\$HTTP_HOST \$HTTPS_HOST \$HTTP_SCHEME \$GEONODE_LB_HOST_IP \$GEONODE_LB_PORT \$GEOSERVER_LB_HOST_IP \$GEOSERVER_LB_PORT \$RESOLVER' < /etc/nginx/nginx.https.available.conf.envsubst > /etc/nginx/nginx.https.available.conf
-envsubst '\$HTTP_HOST \$HTTPS_HOST \$HTTP_SCHEME \$GEONODE_LB_HOST_IP \$GEONODE_LB_PORT \$GEOSERVER_LB_HOST_IP \$GEOSERVER_LB_PORT' < /etc/nginx/sites-enabled/geonode.conf.envsubst > /etc/nginx/sites-enabled/geonode.conf
+envsubst '\$HTTP_HOST \$PUBLIC_HOST \$HTTPS_HOST \$HTTP_SCHEME \$GEONODE_LB_HOST_IP \$GEONODE_LB_PORT \$GEOSERVER_LB_HOST_IP \$GEOSERVER_LB_PORT \$RESOLVER' < /etc/nginx/nginx.conf.envsubst > /etc/nginx/nginx.conf
+envsubst '\$HTTP_HOST \$PUBLIC_HOST \$HTTPS_HOST \$HTTP_SCHEME \$GEONODE_LB_HOST_IP \$GEONODE_LB_PORT \$GEOSERVER_LB_HOST_IP \$GEOSERVER_LB_PORT \$RESOLVER' < /etc/nginx/nginx.https.available.conf.envsubst > /etc/nginx/nginx.https.available.conf
+envsubst '\$HTTP_HOST \$PUBLIC_HOST \$HTTPS_HOST \$HTTP_SCHEME \$GEONODE_LB_HOST_IP \$GEONODE_LB_PORT \$GEOSERVER_LB_HOST_IP \$GEOSERVER_LB_PORT' < /etc/nginx/sites-enabled/geonode.conf.envsubst > /etc/nginx/sites-enabled/geonode.conf
 
 echo "Enabling or not https configuration"
 if [ -z "${HTTPS_HOST}" ]; then

--- a/docker/nginx/geonode.conf.envsubst
+++ b/docker/nginx/geonode.conf.envsubst
@@ -105,8 +105,8 @@ location / {
   add_header Access-Control-Allow-Methods "GET, POST, PUT, PATCH, OPTIONS";
   
   proxy_redirect              off;
-  proxy_set_header            Host $host;
-  proxy_set_header            Origin $HTTP_SCHEME://$host;
+  proxy_set_header            Host $PUBLIC_HOST;
+  proxy_set_header            Origin $HTTP_SCHEME://$PUBLIC_HOST;
   proxy_set_header            X-Real-IP $remote_addr;
   proxy_set_header            X-Forwarded-Host $server_name;
   proxy_set_header            X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Nginx configuration uses `$host` variable that doesn't provide custom ports, causing errors with `request.build_absolute_url`. This PR aims to fix providing also non-standard port specified as `HTTP_PORT`/`HTTPS_PORT`.

Related issues:
- https://github.com/GeoNode/geonode-project/issues/386
- https://github.com/GeoNode/geonode-project/issues/217
- https://github.com/GeoNode/geonode-project/issues/290
- https://github.com/GeoNode/geonode/issues/11734