### PR TITLE
[Fixes #42] Dynamicully set CORS  ALLOW ORIGINS

### DIFF
--- a/docker/nginx/docker-entrypoint.sh
+++ b/docker/nginx/docker-entrypoint.sh
@@ -44,6 +44,14 @@ export GEONODE_LB_PORT=${GEONODE_LB_PORT:-8000}
 export GEOSERVER_LB_HOST_IP=${GEOSERVER_LB_HOST_IP:-geoserver}
 export GEOSERVER_LB_PORT=${GEOSERVER_LB_PORT:-8080}
 
+# Set Access-Control-Allow-Origin based on CORS_ALLOW_ALL_ORIGINS
+if [ "$(echo ${CORS_ALLOW_ALL_ORIGINS} | tr '[:upper:]' '[:lower:]')" = "true" ]; then
+    export NGINX_ALLOW_ORIGIN="*"
+else
+    NGINX_ALLOW_ORIGIN=$(echo "${SITEURL}" | sed -e 's|^https\?://||' -e 's|/$||')
+    export NGINX_ALLOW_ORIGIN
+fi
+
 defined_envs=$(printf '${%s} ' $(env | cut -d= -f1))
 
 echo "Replacing environment variables"

--- a/docker/nginx/geonode.conf.envsubst
+++ b/docker/nginx/geonode.conf.envsubst
@@ -97,6 +97,7 @@ location / {
       add_header Content-Length 0;
       add_header Content-Type text/plain;
       add_header Access-Control-Max-Age 1728000;
+      add_header Access-Control-Allow-Origin "$NGINX_ALLOW_ORIGIN";
       return 200;
   }
 


### PR DESCRIPTION
@giohappy @ridoo 

I'd suggest to add the header for now as geoserver does (with Tomcat). As said in the ticket django-cors-headers is enabled with django in case somebody uses some other fe server than nginx

My take on this is:

If `CORS_ALLOW_ALL_ORIGINS = True`

https://github.com/GeoNode/geonode/blob/684a1f3572a39b6ab8ba5a6ce7ea4d96fc739c8c/.env.sample#L134

we set the wildcard and all origins will be allowed

![2024-05-20 11 13 23 AM](https://github.com/GeoNode/geonode-docker/assets/20478652/8142e4b9-e937-4545-9a94-68ce25fb61a4)

Else the domain name of SITEURL will be set
https://github.com/GeoNode/geonode/blob/684a1f3572a39b6ab8ba5a6ce7ea4d96fc739c8c/.env.sample#L44

![2024-05-20 11 11 52 AM](https://github.com/GeoNode/geonode-docker/assets/20478652/f4f5efd6-c068-4bcb-8447-9b55893f251f)
![2024-05-20 11 05 36 AM](https://github.com/GeoNode/geonode-docker/assets/20478652/ed0cc15f-a915-4494-b94c-7f1bab67daeb)

