### PR TITLE
Fix sitemap.xml 404 error

### DIFF
--- a/docker/nginx/geonode.conf.envsubst
+++ b/docker/nginx/geonode.conf.envsubst
@@ -125,10 +125,13 @@ location / {
   uwsgi_request_buffering off;
 
   location ~* \.(?:js|jpg|jpeg|gif|png|tgz|gz|rar|bz2|doc|pdf|ppt|tar|wav|bmp|ttf|rtf|swf|ico|flv|woff|woff2|svg|xml)$ {
-      gzip_static always;
+    gzip_static always;
+
+    if ($uri != /sitemap.xml) {
       expires 30d;
       access_log off;
       add_header Pragma "public";
       add_header Cache-Control "max-age=31536000, public";
+    }
   }
 }


### PR DESCRIPTION
This simple fix solves the 404 error into geonode sitemap (observed also in https://stable.demo.geonode.org/sitemap.xml)

The problem occurs because on line 127, there is a location directive to produces cache from static files, but sitemap.xml is generated by the django app. This behavior is not observed into robots.txt and version.txt, because the txt extension is not listed on regexp.