### PR TITLE
Strip WWW-Authenticate headers from Geoserver

### DIFF
--- a/docker/nginx/geonode.conf.envsubst
+++ b/docker/nginx/geonode.conf.envsubst
@@ -46,6 +46,8 @@ location /geoserver {
   # (see https://sandro-keil.de/blog/2017/07/24/let-nginx-start-if-upstream-host-is-unavailable-or-down/)
   set $upstream $GEOSERVER_LB_HOST_IP:$GEOSERVER_LB_PORT;
 
+  proxy_pass http://$upstream;
+
   proxy_set_header X-Forwarded-Host $host;
   proxy_set_header X-Forwarded-Server $host;
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -54,7 +56,9 @@ location /geoserver {
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection "upgrade";
   proxy_hide_header X-Frame-Options;
-  proxy_pass http://$upstream;
+  # strip basic auth headers (mainly for the /rest requests from the client)
+  proxy_hide_header WWW-Authenticate;
+
   proxy_http_version 1.1;
   proxy_redirect http://$upstream $HTTP_SCHEME://$HTTP_HOST;
   proxy_request_buffering  off;


### PR DESCRIPTION
The client performs REST requests to a subset ot GS rest apis. The APIs are not enabled for anonymous users, but the client still prompts them and since the WWW-Authenticate header is returned, anynmous users are presented with the basic auth prompt.

We strip WWW-Authenticate header from any Geosever response here, since we need or never rely on it.