### PR TITLE
Enable HTTP 2

### DIFF
--- a/docker/nginx/docker-entrypoint.sh
+++ b/docker/nginx/docker-entrypoint.sh
@@ -48,7 +48,8 @@ else
         fi
 fi
 
-export HTTP2_TOGGLE=${HTTP2_TOGGLE:-on}
+export HTTP_VERSION=${HTTP_VERSION:-2}
+export HTTP2_TOGGLE=$([ "$HTTP_VERSION" = "2" ] && echo "on" || echo "off")
 export HTTP_SCHEME=${HTTP_SCHEME:-http}
 export GEONODE_LB_HOST_IP=${GEONODE_LB_HOST_IP:-django}
 export GEONODE_LB_PORT=${GEONODE_LB_PORT:-8000}

--- a/docker/nginx/docker-entrypoint.sh
+++ b/docker/nginx/docker-entrypoint.sh
@@ -48,6 +48,7 @@ else
         fi
 fi
 
+export HTTP2_TOGGLE=${HTTP2_TOGGLE:-on}
 export HTTP_SCHEME=${HTTP_SCHEME:-http}
 export GEONODE_LB_HOST_IP=${GEONODE_LB_HOST_IP:-django}
 export GEONODE_LB_PORT=${GEONODE_LB_PORT:-8000}

--- a/docker/nginx/nginx.conf.envsubst
+++ b/docker/nginx/nginx.conf.envsubst
@@ -9,6 +9,7 @@ events {
 
 http {
     server_names_hash_bucket_size  64;
+    http2 on;
 
     # Allow Nginx to resolve Docker host names (see https://sandro-keil.de/blog/2017/07/24/let-nginx-start-if-upstream-host-is-unavailable-or-down/)
     resolver $RESOLVER; # it seems rancher uses 169.254.169.250 instead of 127.0.0.11 which works well in docker-compose (see /etc/resolv.conf)

--- a/docker/nginx/nginx.conf.envsubst
+++ b/docker/nginx/nginx.conf.envsubst
@@ -9,7 +9,7 @@ events {
 
 http {
     server_names_hash_bucket_size  64;
-    http2 on;
+    http2 $HTTP2_TOGGLE;
 
     # Allow Nginx to resolve Docker host names (see https://sandro-keil.de/blog/2017/07/24/let-nginx-start-if-upstream-host-is-unavailable-or-down/)
     resolver $RESOLVER; # it seems rancher uses 169.254.169.250 instead of 127.0.0.11 which works well in docker-compose (see /etc/resolv.conf)


### PR DESCRIPTION
Enable the HTTP 2 protocol for all GeoNode services.