### PR TITLE
Fix JAVA_OPTS typo

### DIFF
--- a/docker/geoserver/Dockerfile
+++ b/docker/geoserver/Dockerfile
@@ -44,6 +44,6 @@ RUN chmod +x /usr/local/bin/*.sh
 
 VOLUME $GEOSERVER_DATA_DIR
 
-ENV JAVA_OPTS="-Djava.awt.headless=true -Dgwc.context.suffix=gwc -XX:+UnlockDiagnosticVMOptions -XX:+LogVMOutput -XX:LogFile=/var/log/jvm.log -Xms2048m -Xmx2048m XX:ParallelGCThreads=4 -Dfile.encoding=UTF8 -Djavax.servlet.request.encoding=UTF-8 -Djavax.servlet.response.encoding=UTF-8 -Duser.timezone=GMT -Dorg.geotools.shapefile.datetime=false -DGS-SHAPEFILE-CHARSET=UTF-8 -DGEOSERVER_CSRF_DISABLED=true -DPRINT_BASE_URL=http://geoserver:8080/geoserver/pdf"
+ENV JAVA_OPTS="-Djava.awt.headless=true -Dgwc.context.suffix=gwc -XX:+UnlockDiagnosticVMOptions -XX:+LogVMOutput -XX:LogFile=/var/log/jvm.log -Xms2048m -Xmx2048m -XX:ParallelGCThreads=4 -Dfile.encoding=UTF8 -Djavax.servlet.request.encoding=UTF-8 -Djavax.servlet.response.encoding=UTF-8 -Duser.timezone=GMT -Dorg.geotools.shapefile.datetime=false -DGS-SHAPEFILE-CHARSET=UTF-8 -DGEOSERVER_CSRF_DISABLED=true -DPRINT_BASE_URL=http://geoserver:8080/geoserver/pdf"
 
 CMD ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
The ParallelGCThreads flag in the default JAVA_OPTS was missing its leading dash ("XX:ParallelGCThreads=4"). The JVM treats a token without a leading dash as the main class, so it aborts at startup with:
 
    Error: Could not find or load main class XX:ParallelGCThreads=4
 
This makes the default geoserver image fail to start. Deployments that override JAVA_OPTS via GEOSERVER_JAVA_OPTS mask the bug, which is presumably why it went unnoticed.
 
Regression introduced in #85.