### PR TITLE
set NGINX base version to 1.31.4

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-ARG NGINX_VERSION=1.31.2
+ARG NGINX_VERSION=1.31.4
 FROM nginx:${NGINX_VERSION}-alpine
 
 RUN apk add --no-cache openssl inotify-tools vim


### PR DESCRIPTION
Upgrading NGINX to remove high/critical vulnerability [CVE-2026-42533](https://my.f5.com/manage/s/article/K000162097).